### PR TITLE
Allow anon inserts for signup

### DIFF
--- a/supabase/migrations/20250826143000_rls_allow_anon_signup.sql
+++ b/supabase/migrations/20250826143000_rls_allow_anon_signup.sql
@@ -1,0 +1,18 @@
+/*
+  # Allow anon insert into users table during signup
+
+  1. Problem
+    - Signup flow fails with permission error because anon role cannot insert into users table.
+
+  2. Solution
+    - Create policy allowing anon role to insert rows when ID exists in auth.users.
+
+  3. Security
+    - Ensures only valid auth user IDs can be inserted.
+*/
+
+-- Allow anon role to insert user row after signup
+CREATE POLICY "users_insert_anon" ON users
+  FOR INSERT
+  TO anon
+  WITH CHECK (id IN (SELECT id FROM auth.users));


### PR DESCRIPTION
## Summary
- add RLS policy allowing `anon` role to insert into `users`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc4b6d064832eab0da7f0fb3e2219