### PR TITLE
feat: trigger-based user profile creation on signup

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -55,30 +55,15 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   const signUp = async (email: string, password: string, name: string) => {
-    const { data, error } = await supabase.auth.signUp({
+    const { error } = await supabase.auth.signUp({
       email,
       password,
+      options: {
+        data: { name },
+      },
     });
 
     if (error) throw error;
-
-    if (data.user) {
-      // Create user profile
-      const { error: profileError } = await supabase
-        .from('users')
-        .insert([
-          {
-            id: data.user.id,
-            email,
-            name,
-            plan: 'free',
-            usage_count: 0,
-            usage_reset_date: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-          },
-        ]);
-
-      if (profileError) throw profileError;
-    }
   };
 
   const signIn = async (email: string, password: string) => {

--- a/supabase/migrations/20250901000000_signup_trigger.sql
+++ b/supabase/migrations/20250901000000_signup_trigger.sql
@@ -1,0 +1,39 @@
+/*
+  # Trigger to populate users table on signup
+
+  1. Create trigger to insert into public.users when a new auth.user is created.
+  2. Remove manual insert policies as insertion is handled automatically.
+*/
+
+-- Drop old insert policies no longer needed
+DROP POLICY IF EXISTS "users_insert_own" ON users;
+DROP POLICY IF EXISTS "users_insert_authenticated" ON users;
+DROP POLICY IF EXISTS "users_insert_anon" ON users;
+
+-- Function to copy data from auth.users to public.users
+CREATE OR REPLACE FUNCTION public.handle_new_auth_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.users (id, email, name, plan, usage_count, usage_reset_date)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'name', ''),
+    'free',
+    0,
+    now() + interval '30 days'
+  );
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger to run the function after a new auth.user is created
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+CREATE TRIGGER on_auth_user_created
+AFTER INSERT ON auth.users
+FOR EACH ROW
+EXECUTE FUNCTION public.handle_new_auth_user();


### PR DESCRIPTION
## Summary
- populate `users` via DB trigger when a new `auth.users` row is created
- streamline sign-up to rely on Supabase metadata instead of manual profile insert

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add12bc348832e980103de9f1d9693