### PR TITLE
Add checkout page and upgrade redirect

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Navigation from '@/components/Navigation';
+import AuthModal from '@/components/AuthModal';
+import { useAuth } from '@/contexts/AuthContext';
+import { useEffect, useState } from 'react';
+
+export default function CheckoutPage() {
+  const { user } = useAuth();
+  const [showAuthModal, setShowAuthModal] = useState(false);
+
+  useEffect(() => {
+    setShowAuthModal(!user);
+  }, [user]);
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Navigation />
+      {user ? (
+        <div className="max-w-3xl mx-auto px-4 py-20">
+          <h1 className="text-3xl font-bold mb-6">Checkout</h1>
+          <p className="text-gray-700">Finalize sua assinatura do plano premium.</p>
+        </div>
+      ) : null}
+      <AuthModal isOpen={showAuthModal} onClose={() => setShowAuthModal(false)} />
+    </div>
+  );
+}
+

--- a/components/HumanizeText.tsx
+++ b/components/HumanizeText.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
@@ -32,6 +33,7 @@ export default function HumanizeText() {
   const [showAuthModal, setShowAuthModal] = useState(false);
   const { toast } = useToast();
   const { user, refreshUser } = useAuth();
+  const router = useRouter();
 
   const FREE_LIMIT = 3;
   const FREE_WORD_LIMIT = 200;
@@ -49,6 +51,14 @@ export default function HumanizeText() {
   const exceedsWordLimit = () => {
     if (!user || user.plan === 'premium') return false;
     return getWordCount(inputText) > FREE_WORD_LIMIT;
+  };
+
+  const handleUpgrade = () => {
+    if (user) {
+      router.push('/checkout');
+    } else {
+      setShowAuthModal(true);
+    }
   };
 
   const handleHumanize = async () => {
@@ -184,7 +194,11 @@ export default function HumanizeText() {
                     )}
                   </div>
                   {user.plan === 'free' && (
-                    <Button size="sm" className="bg-gradient-to-r from-blue-600 to-red-600 text-white">
+                    <Button
+                      size="sm"
+                      onClick={handleUpgrade}
+                      className="bg-gradient-to-r from-blue-600 to-red-600 text-white"
+                    >
                       Fazer Upgrade
                     </Button>
                   )}


### PR DESCRIPTION
## Summary
- add checkout page that prompts unauthenticated users to sign in
- route 'Fazer Upgrade' button to checkout for logged-in users or show auth modal when not logged

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adea87a2a0832e94398d3067884131