### PR TITLE
Replace Radix progress with custom component and fix lint

### DIFF
--- a/app/copywriting/page.tsx
+++ b/app/copywriting/page.tsx
@@ -313,7 +313,7 @@ export default function CopywritingPage() {
                       <Star key={i} className="h-5 w-5 text-yellow-400 fill-current" />
                     ))}
                   </div>
-                  <p className="text-gray-600 mb-6 italic">"{testimonial.text}"</p>
+                  <p className="text-gray-600 mb-6 italic">&quot;{testimonial.text}&quot;</p>
                   <div>
                     <div className="font-semibold text-gray-900">{testimonial.name}</div>
                     <div className="text-sm text-gray-500">{testimonial.company}</div>

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -1,28 +1,31 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
->(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
-    ref={ref}
-    className={cn(
-      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
-      className
-    )}
-    {...props}
-  >
-    <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
-      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
-    />
-  </ProgressPrimitive.Root>
-))
-Progress.displayName = ProgressPrimitive.Root.displayName
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+}
 
-export { Progress }
+const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
+  ({ className, value = 0, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+        className
+      )}
+      {...props}
+    >
+      <div
+        className="h-full bg-primary transition-all"
+        style={{ transform: `translateX(-${100 - value}%)` }}
+      />
+    </div>
+  )
+);
+Progress.displayName = "Progress";
+
+export { Progress };
+


### PR DESCRIPTION
## Summary
- replace Radix-based progress component with simple div implementation to avoid build-time syntax errors
- escape quotes in copywriting page testimonial section

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_68ae0085be7c832e82862a0c1471d482