### PR TITLE
Fix Supabase plan query typing

### DIFF
--- a/hooks/usePlans.ts
+++ b/hooks/usePlans.ts
@@ -10,9 +10,10 @@ export function usePlans() {
   useEffect(() => {
     const fetchPlans = async () => {
       const { data, error } = await supabase
-        .from<Plan>('plans')
+        .from('plans')
         .select('*')
-        .order('price');
+        .order('price')
+        .returns<Plan[]>();
       if (!error && data) {
         setPlans(data);
       }


### PR DESCRIPTION
## Summary
- remove incorrect generic from Supabase `from` call
- specify Plan return type with `.returns` to avoid TypeScript error

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `Inter` from Google Fonts)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68af1a9b87ac832ebc8fcd017143cd79