### PR TITLE
feat: show selected plan on checkout page

### DIFF
--- a/app/checkout/page.tsx
+++ b/app/checkout/page.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
+import { useSearchParams } from 'next/navigation';
+import { usePlans } from '@/hooks/usePlans';
 
 import {
   Card,
@@ -20,6 +22,10 @@ import { Separator } from '@/components/ui/separator';
 
 export default function CheckoutPage() {
   const { user } = useAuth();
+  const searchParams = useSearchParams();
+  const { plans } = usePlans();
+  const planSlug = searchParams.get('plan') || 'premium';
+  const selectedPlan = plans.find((p) => p.slug === planSlug);
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [formData, setFormData] = useState({
     cpf: '',
@@ -57,11 +63,26 @@ export default function CheckoutPage() {
             <CardHeader>
               <CardTitle>Checkout</CardTitle>
               <CardDescription>
-                Finalize sua assinatura do plano premium.
+                {selectedPlan
+                  ? `Finalize sua assinatura do plano ${selectedPlan.name}.`
+                  : 'Carregando informações do plano...'}
               </CardDescription>
             </CardHeader>
             <form onSubmit={handleSubmit}>
               <CardContent className="space-y-8">
+                {selectedPlan && (
+                  <div className="p-4 bg-gray-50 rounded-md">
+                    <h2 className="text-md font-semibold">Plano Selecionado</h2>
+                    <p className="text-sm text-gray-600">
+                      {selectedPlan.name} - R$ {selectedPlan.price}/mês
+                    </p>
+                    {selectedPlan.humanizations_per_month !== null && (
+                      <p className="text-xs text-gray-500">
+                        {selectedPlan.humanizations_per_month} humanizações por mês
+                      </p>
+                    )}
+                  </div>
+                )}
                 <div>
                   <h2 className="text-lg font-semibold mb-4">
                     Informações Pessoais

--- a/components/HumanizeText.tsx
+++ b/components/HumanizeText.tsx
@@ -56,9 +56,11 @@ export default function HumanizeText() {
     return getWordCount(inputText) > currentPlan.word_limit;
   };
 
-  const handleUpgrade = () => {
+  const handleUpgrade = (planSlug?: string) => {
     if (user) {
-      router.push('/checkout');
+      const slug =
+        planSlug || (currentPlan?.slug === 'free' ? 'pro' : 'premium');
+      router.push(`/checkout?plan=${slug}`);
     } else {
       setShowAuthModal(true);
     }
@@ -208,7 +210,7 @@ export default function HumanizeText() {
                   {currentPlan?.slug !== 'premium' && (
                     <Button
                       size="sm"
-                      onClick={handleUpgrade}
+                      onClick={() => handleUpgrade()}
                       className="bg-gradient-to-r from-blue-600 to-red-600 text-white"
                     >
                       Fazer Upgrade
@@ -621,7 +623,10 @@ export default function HumanizeText() {
                     <span>Histórico de textos</span>
                   </li>
                 </ul>
-                <Button className="w-full bg-blue-500 hover:bg-blue-600 text-white">
+                <Button
+                  className="w-full bg-blue-500 hover:bg-blue-600 text-white"
+                  onClick={() => handleUpgrade('pro')}
+                >
                   Escolher Pro
                 </Button>
               </CardContent>
@@ -678,7 +683,10 @@ export default function HumanizeText() {
                     <span>Consultoria personalizada</span>
                   </li>
                 </ul>
-                <Button className="w-full bg-gradient-to-r from-blue-600 to-red-600 hover:from-blue-700 hover:to-red-700 text-white">
+                <Button
+                  className="w-full bg-gradient-to-r from-blue-600 to-red-600 hover:from-blue-700 hover:to-red-700 text-white"
+                  onClick={() => handleUpgrade('premium')}
+                >
                   Escolher Premium
                 </Button>
               </CardContent>


### PR DESCRIPTION
## Summary
- pass plan selection to checkout via query string
- display selected plan details on checkout page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b052f50810832eb88228840dcbbab2